### PR TITLE
Fix broken links. TODO: change category names

### DIFF
--- a/docs/open-source/faq.md
+++ b/docs/open-source/faq.md
@@ -16,7 +16,7 @@ Error response from daemon: failed to create task for container: failed to creat
 
 __Potential causes:__
 
-The [container](./reference/pipelines/yaml/container.md) defined in the [step](/category/steps) does not contain `/bin/sh`.
+The [container](/docs/open-source/reference/pipelines/yaml/container) defined in the [step](/docs/category/steps-1) does not contain `/bin/sh`.
 
 __Solutions:__
 
@@ -32,8 +32,8 @@ Error response from daemon: pull access denied for IMAGE_NAME, repository does n
 
 __Potential causes:__
 
-1. The [container](./reference/pipelines/yaml/container.md) defined in the [step](/category/steps) does not exist
-2. The [container](./reference/pipelines/yaml/container.md) defined in the [step](/category/steps) is private, and requires authentication
+1. The [container](/docs/open-source/reference/pipelines/yaml/container) defined in the [step](/docs/category/steps-1) does not exist
+2. The [container](/docs/open-source/reference/pipelines/yaml/container) defined in the [step](/docs/category/steps-1) is private, and requires authentication
 
 __Solutions:__
 
@@ -50,7 +50,7 @@ exec /bin/sh: exec format error
 
 __Potential causes:__
 
-The [container](./reference/pipelines/yaml/container.md) defined in the [step](/category/steps) is for a different OS and/or architecture.
+The [container](/docs/open-source/reference/pipelines/yaml/container) defined in the [step](/docs/category/steps-1) is for a different OS and/or architecture.
 
 __Solutions:__
 

--- a/docs/open-source/installation/quick_start.md
+++ b/docs/open-source/installation/quick_start.md
@@ -1,9 +1,7 @@
 ---
+title: Quick Start
 sidebar_position: 1
-slug: '/'
 ---
-
-# Quick Start
 
 Let's discover **[Harness Open Source](https://gitness.com)** in less than 30 seconds.
 

--- a/docs/open-source/overview.md
+++ b/docs/open-source/overview.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Overview
 
-Harness Open Source is an end-to-end open source software development platform from [Harness](https://www.harness.io/) that unifies managing your [source code repositories](/category/repositories), [CI/CD pipelines](/pipelines/overview), [hosted development environments](/category/gitspaces), and [artifact management](/category/registries).
+Harness Open Source is an end-to-end open source software development platform from [Harness](https://www.harness.io/) that unifies managing your [source code repositories](/docs/category/repositories), [CI/CD pipelines](/docs/open-source/pipelines/overview), [hosted development environments](/docs/category/gitspaces), and [artifact management](/docs/category/registries).
 
 Here’s a short overview of the capabilities:
 

--- a/docs/open-source/pipelines/conditions.md
+++ b/docs/open-source/pipelines/conditions.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Conditions
 
-Conditions limit pipeline [step](/category/steps) execution at runtime. Harness Open Source sets [variables](../reference/pipelines/expression_variables.md) that can be used in conditions.
+Conditions limit pipeline [step](/docs/category/steps-1) execution at runtime. Harness Open Source sets [variables](../reference/pipelines/expression_variables.md) that can be used in conditions.
 
 :::tip
 

--- a/docs/open-source/pipelines/overview.md
+++ b/docs/open-source/pipelines/overview.md
@@ -18,4 +18,4 @@ Harness Open Source supports multiple pipelines per repository.
 ## Next steps
 
 - Create [triggers](triggers)
-- See [sample pipelines](/category/samples) for popular tools and languages
+- See [sample pipelines](/docs/category/samples) for popular tools and languages

--- a/docs/open-source/pipelines/stages.md
+++ b/docs/open-source/pipelines/stages.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Stages
 
-A stage contains one or more [steps](/category/steps). 
+A stage contains one or more [steps](/docs/category/steps-1). 
 
 ## Single
 

--- a/docs/open-source/registries/overview.md
+++ b/docs/open-source/registries/overview.md
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 An **Artifact Registry** is a central location for storing and managing software artifacts, such as container images or helm charts used throughout the software development lifecycle. To create one, follow these steps:
 
 1. In your [project](../administration/project-management.md), select **Artifact Registries**, and then select **New Artifact Registry**
-2. Select a [registry type](/registries/whats-supported#supported-registry-types). 
+2. Select a [registry type](/docs/open-source/registries/whats-supported#supported-registry-types). 
 3. Enter a **Registry Name** and optional **Description** and **Labels**.
     :::tip
     This registry name must start with a letter and can only contain lowercase alphanumerics, `_`, `.` and `-`
@@ -24,7 +24,7 @@ An **Upstream Proxy** for an **Artifact Registry** is a proxy configuration that
 
 1. In your [project](../administration/project-management.md), select **Artifact Registries**. 
 2. Select the dropdown next to **New Artifact Registry**, and then select **Upstream Proxy**.
-3. Select a [registry type](/registries/whats-supported#supported-registry-types).
+3. Select a [registry type](/docs/open-source/registries/whats-supported#supported-registry-types).
 4. Enter the **Upstream Proxy Key**. This is the identifier or name for the proxy within Gitness and is chosen by you. 
    :::tip
     This proxy key must start with a letter and can only contain lowercase alphanumerics, `_`, `.` and `-`

--- a/src/components/Docs/data/openSourceData.tsx
+++ b/src/components/Docs/data/openSourceData.tsx
@@ -26,7 +26,7 @@ import {
             module: MODULES.code,
             description:
               "Learn the benefits, features, and key concepts of the Harness Open Source.",
-            link: "/docs/category/get-started-with-opensource",
+            link: "/docs/open-source/installation/quick_start",
           },
           {
             title: "Onboarding guide",


### PR DESCRIPTION
The broken links are fixed but some of the links look like: `/docs/category/steps-1` since we have a steps folder in open source and harness. Probably should change that for sanity at some point, but just fixing for now. 

## Description

* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
